### PR TITLE
Add Type Definition for Support Typescript & Add async function

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The git repo is shallowly cloned by default. To make a complete clone, set `opti
 When the operation is finished, `callback` is called. The first argument to `callback` is either
 `null` or an `Error` object if an error occurred.
 
+### `gitPullOrClone.async(url, outPath[, options])`
+
+Work as same as `gitPullOrClone(url, outPath[, options], callback)` but handle callback as async function
+
 ## License
 
 MIT. Copyright (c) [Feross Aboukhadijeh](http://feross.org).

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+interface Options {
+    depth?: number
+}
+
+type Callback = (error?: Error) => void
+
+type GitPullOrClone = {
+    (url: string, outPath: string, opts?: Options | Callback, cb?: Callback): void
+    async: (url: string, outPath: string, opts?: Options) => Promise<void>
+}
+
+const gitPullOrClone: GitPullOrClone
+
+export = gitPullOrClone

--- a/index.js
+++ b/index.js
@@ -57,3 +57,20 @@ function spawn (command, args, opts, cb) {
   })
   return child
 }
+
+gitPullOrClone.async = function(url, outPath, opts) {
+  return new Promise(
+    (resolve, reject) =>
+      gitPullOrClone(
+        url,
+        outPath,
+        opts || {},
+        err => {
+          if (!err) {
+            resolve()
+          }
+          reject(err)
+        }
+      )
+  )
+}


### PR DESCRIPTION
Nowadays most of developer develop JS in the form of Typescript and using async function instead of callback design pattern. (I am one of that developer too lol)

So I add the type definition to this library and also add the async function for `gitPullOrClone` using as `gitPullOrClone.async` to enhance the ability of gitPullOrClone.

I hope this pull request will be merged.

Thanks 😄 